### PR TITLE
Fix notebook tab order for RTL layout

### DIFF
--- a/main.py
+++ b/main.py
@@ -342,7 +342,7 @@ class HRApp(tk.Tk):
         # إنشاء notebook محسن
         style = ttk.Style()
         style.theme_use('clam')
-        style.configure('TNotebook', tabposition='n')
+        style.configure('TNotebook', tabposition='ne')
         style.configure('TNotebook.Tab', padding=[20, 10])
 
         self.notebook = ttk.Notebook(self)


### PR DESCRIPTION
## Summary
- align the notebook's tab bar to start from the right by setting `tabposition='ne'`

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68779c037d68832a88401ec7fdd2470e