### PR TITLE
Reverse notebook tab order for RTL

### DIFF
--- a/main.py
+++ b/main.py
@@ -356,6 +356,10 @@ class HRApp(tk.Tk):
         self.create_report_tab()
         self.create_settings_tab()
 
+        # عكس ترتيب التبويبات لعرضها من اليمين لليسار
+        for tab in self.notebook.tabs():
+            self.notebook.insert(0, tab)
+
         # إنشاء قاموس البيانات
         self.emp_dict = {}
         self.refresh_employees_combobox()


### PR DESCRIPTION
## Summary
- reverse tab display order to better support Arabic RTL

## Testing
- `python3 -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68779ec4dc48832a82b5ab5a17fda54d